### PR TITLE
Feature Improvement: Automatically download and load MetaCLIP checkpoints 

### DIFF
--- a/src/open_clip/pretrained.py
+++ b/src/open_clip/pretrained.py
@@ -46,18 +46,24 @@ _VITB32 = dict(
     laion2b_e16="https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-laion2b_e16-af8dbd0c.pth",
     laion400m_e31="https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-quickgelu-laion400m_e31-d867053b.pt",
     laion400m_e32="https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-quickgelu-laion400m_e32-46683a32.pt",
+    metaclip400m="https://dl.fbaipublicfiles.com/MMPT/metaclip/b32_400m.pt",
+    metaclip2_5b="https://dl.fbaipublicfiles.com/MMPT/metaclip/b32_fullcc2.5b.pt"
 )
 
 _VITB32_quickgelu = dict(
     openai="https://openaipublic.azureedge.net/clip/models/40d365715913c9da98579312b702a82c18be219cc2a73407c4526f58eba950af/ViT-B-32.pt",
     laion400m_e31="https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-quickgelu-laion400m_e31-d867053b.pt",
     laion400m_e32="https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_32-quickgelu-laion400m_e32-46683a32.pt",
+    metaclip400m="https://dl.fbaipublicfiles.com/MMPT/metaclip/b32_400m.pt",
+    metaclip2_5b="https://dl.fbaipublicfiles.com/MMPT/metaclip/b32_fullcc2.5b.pt"
 )
 
 _VITB16 = dict(
     openai="https://openaipublic.azureedge.net/clip/models/5806e77cd80f8b59890b7e101eabd078d9fb84e6937f9e85e4ecb61988df416f/ViT-B-16.pt",
     laion400m_e31="https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_16-laion400m_e31-00efa78f.pt",
     laion400m_e32="https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_b_16-laion400m_e32-55e67d44.pt",
+    metaclip400m="https://dl.fbaipublicfiles.com/MMPT/metaclip/b16_400m.pt",
+    metaclip2_5b="https://dl.fbaipublicfiles.com/MMPT/metaclip/b16_fullcc2.5b.pt"
 )
 
 _VITB16_PLUS_240 = dict(
@@ -69,6 +75,8 @@ _VITL14 = dict(
     openai="https://openaipublic.azureedge.net/clip/models/b8cca3fd41ae0c99ba7e8951adf17d267cdb84cd88be6f7c2e0eca1737a03836/ViT-L-14.pt",
     laion400m_e31='https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_l_14-laion400m_e31-69988bb6.pt',
     laion400m_e32='https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/vit_l_14-laion400m_e32-3d133497.pt',
+    metaclip400m='https://dl.fbaipublicfiles.com/MMPT/metaclip/l14_400m.pt',
+    metaclip2_5b='https://dl.fbaipublicfiles.com/MMPT/metaclip/l14_fullcc2.5b.pt'
 )
 
 _VITL14_336 = dict(

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,0 +1,33 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+
+import torch
+from PIL import Image
+from open_clip import tokenizer
+import open_clip
+import os
+
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+
+def test_inference():
+    for model_name in ["ViT-B-32", "ViT-B-32-quickgelu", "ViT-B-16", "ViT-L-14"]:
+        for pretrained in ["metaclip400m", "metaclip2_5b"]:
+            model, _, preprocess = open_clip.create_model_and_transforms(
+                model_name, pretrained=pretrained
+            )
+
+            current_dir = os.path.dirname(os.path.realpath(__file__))
+
+            image = preprocess(Image.open(current_dir + "/../docs/CLIP.png")).unsqueeze(
+                0
+            )
+            text = tokenizer.tokenize(["a diagram", "a dog", "a cat"])
+
+            with torch.no_grad():
+                image_features = model.encode_image(image)
+                text_features = model.encode_text(text)
+
+                text_probs = (100.0 * image_features @ text_features.T).softmax(dim=-1)
+
+            assert text_probs.cpu().numpy()[0].tolist() == [1.0, 0.0, 0.0]


### PR DESCRIPTION
Feature Improvement based on Issue #26 
#### Code modified/added
- `src/open_clip/pretrained.py` 
- `tests/test.py`

Now loading MetaCLIP(ViT-B-32, ViT-B32-quickgelu, ViT-B-16, ViT-L-14) can be done as: 
```py
# Load MetaCLIP B32 400M
model, _, preprocess = open_clip.create_model_and_transforms('ViT-B-32-quickgelu', pretrained='metaclip400m')

# Load MetaCLIP B32 2.5B
model, _, preprocess = open_clip.create_model_and_transforms('ViT-B-32-quickgelu', pretrained='metaclip2_5b')
```

And thanks for reviewing this PR in advance. 
